### PR TITLE
Handle text generation errors

### DIFF
--- a/app/admin/agent/page.tsx
+++ b/app/admin/agent/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useMdxDraft } from '@/components/context/mdx-draft-context'
 import SpinnerModal from '../_components/SpinnerModal'
 import { Textarea } from '@/components/ui/textarea'
+import { toast } from 'sonner'
 
 export const dynamic = 'force-dynamic'
 
@@ -95,7 +96,9 @@ export default function AgentPage() {
       })
 
       if (!res.ok) {
-        throw new Error(`Fehler beim Abrufen der Daten: ${res.statusText}`)
+        const errData = await res.json().catch(() => null)
+        const message = errData?.error || res.statusText
+        throw new Error(`Fehler beim Abrufen der Daten: ${message}`)
       }
 
       const data = await res.json()
@@ -111,6 +114,9 @@ export default function AgentPage() {
       router.push(`/admin/create?title=${encodeURIComponent(title)}`)
     } catch (err) {
       console.error('❌ Fehler beim Text generieren:', err)
+      toast.error('Fehler beim Text generieren', {
+        description: typeof err === 'string' ? err : (err as Error).message,
+      })
     } finally {
       setGenerating(false)
     }

--- a/app/api/generate-text/route.ts
+++ b/app/api/generate-text/route.ts
@@ -36,6 +36,7 @@ export async function POST(request: Request) {
     })
   } catch (error) {
     console.error('Fehler bei der Text-Generierung:', error)
-    return NextResponse.json({ error: 'Fehler bei der Text-Generierung' }, { status: 500 })
+    const message = error instanceof Error ? error.message : 'Fehler bei der Text-Generierung'
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- add toast notifications on text generation failure to make it clear when generation fails
- forward server error messages from /api/generate-text to client

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685c5b2b3158832fa3abee9b7a43ba63